### PR TITLE
implement orphaned block count

### DIFF
--- a/core/src/client/client.rs
+++ b/core/src/client/client.rs
@@ -1498,6 +1498,20 @@ impl BlockChainClient for Client {
         Self::block_hash(&chain, &self.miner, id).and_then(|hash| chain.block(&hash))
     }
 
+    fn orphaned_block_count(&self, id: BlockId) -> u64 {
+        let chain = self.chain.read();
+
+        // pending block height does not have orphaned blocks
+        if let BlockId::Pending = id {
+            return 0;
+        }
+
+        match Self::block_hash(&chain, &self.miner, id) {
+            Some(hash) => chain.orphaned_block_count(&hash),
+            _ => 0,
+        }
+    }
+
     fn block_status(&self, id: BlockId) -> BlockStatus {
         if let BlockId::Pending = id {
             return BlockStatus::Pending;

--- a/core/src/client/test_client.rs
+++ b/core/src/client/test_client.rs
@@ -670,6 +670,8 @@ impl BlockChainClient for TestBlockChainClient {
             .map(encoded::Block::new)
     }
 
+    fn orphaned_block_count(&self, _id: BlockId) -> u64 { 0 }
+
     fn block_extra_info(&self, id: BlockId) -> Option<BTreeMap<String, String>> {
         self.block(id)
             .map(|block| block.view().header())

--- a/core/src/client/traits.rs
+++ b/core/src/client/traits.rs
@@ -65,6 +65,9 @@ pub trait BlockChainClient: Sync + Send {
     /// Get raw block data by block header hash.
     fn block(&self, id: BlockId) -> Option<encoded::Block>;
 
+    /// Get the orphaned block count since the given block number.
+    fn orphaned_block_count(&self, id: BlockId) -> u64;
+
     /// Get block status by block header hash.
     fn block_status(&self, id: BlockId) -> BlockStatus;
 

--- a/rpc/src/impls/eth.rs
+++ b/rpc/src/impls/eth.rs
@@ -368,15 +368,11 @@ where
         ))
     }
 
+    // ATTENTION!!! Changed this function to return the orphaned block count since given block number only for Unity-POC
     fn block_transaction_count_by_number(&self, num: BlockNumber) -> BoxFuture<Option<RpcU256>> {
-        Box::new(future::ok(match num {
-            BlockNumber::Pending => Some(self.miner.status().transactions_in_pending_block.into()),
-            _ => {
-                self.client
-                    .block(num.into())
-                    .map(|block| block.transactions_count().into())
-            }
-        }))
+        Box::new(future::ok(Some(
+            self.client.orphaned_block_count(num.into()).into(),
+        )))
     }
 
     fn code_at(&self, address: RpcH256, num: Trailing<BlockNumber>) -> BoxFuture<Bytes> {


### PR DESCRIPTION
implemented orphaned block count calculation
temporarily changed rpc api `eth_getBlockTransactionCount` to get orphaned block count

Do not merge this pr now. More tests needed 